### PR TITLE
Changes to MethodCallExpression usage

### DIFF
--- a/src/main/java/sa/com/cloudsolutions/antikythera/depsolver/DTOHandler.java
+++ b/src/main/java/sa/com/cloudsolutions/antikythera/depsolver/DTOHandler.java
@@ -2,8 +2,6 @@ package sa.com.cloudsolutions.antikythera.depsolver;
 
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.stmt.Statement;
-import com.github.javaparser.ast.type.ClassOrInterfaceType;
-import com.github.javaparser.ast.type.PrimitiveType;
 import sa.com.cloudsolutions.antikythera.configuration.Settings;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
@@ -432,7 +430,7 @@ public class DTOHandler extends ClassProcessor {
                 processor.copyDTO(args[0]);
             }
             else {
-                processor.copyDTO(processor.classToPath(args[0]));
+                processor.copyDTO(AbstractCompiler.classToPath(args[0]));
             }
         }
     }
@@ -443,6 +441,6 @@ public class DTOHandler extends ClassProcessor {
 
     @Override
     protected ModifierVisitor<?> createTypeCollector() {
-        return new ClassProcessor.TypeCollector();
+        return new TypeCollector();
     }
 }

--- a/src/main/java/sa/com/cloudsolutions/antikythera/depsolver/Resolver.java
+++ b/src/main/java/sa/com/cloudsolutions/antikythera/depsolver/Resolver.java
@@ -31,6 +31,7 @@ import sa.com.cloudsolutions.antikythera.exception.AntikytheraException;
 import sa.com.cloudsolutions.antikythera.exception.DepsolverException;
 import sa.com.cloudsolutions.antikythera.exception.GeneratorException;
 import sa.com.cloudsolutions.antikythera.parser.AbstractCompiler;
+import sa.com.cloudsolutions.antikythera.parser.Callable;
 import sa.com.cloudsolutions.antikythera.parser.ImportUtils;
 import sa.com.cloudsolutions.antikythera.parser.ImportWrapper;
 import sa.com.cloudsolutions.antikythera.parser.MCEWrapper;
@@ -43,10 +44,10 @@ import java.util.Optional;
 public class Resolver {
 
     /**
-     * Resolve a field that is accessed through the this. prefix
+     * Resolve a field that is accessed through the <code>this.</code> prefix
      * @param node a graph node representing the current context
      * @param value the field access expression
-     * @return
+     * @return a graph node representing the resolved field
      */
     public static GraphNode resolveThisFieldAccess(GraphNode node, FieldAccessExpr value) {
         TypeDeclaration<?> decl = node.getEnclosingType();
@@ -79,11 +80,11 @@ public class Resolver {
 
     /**
      * Resolve a field access expression
-     * If the expression has a this. prefix then the field is resolved from the current class with
-     * help from the resolveThisField method
+     * If the expression has a <code>this.</code> prefix, then the field is resolved within the
+     * current class with help from the resolveThisField method
      * @param node represents a type
      * @param value a field access expression
-     * @return
+     * @return a graph node representing the resolved field
      */
     public static GraphNode resolveField(GraphNode node, FieldAccessExpr value) {
         Expression scope = value.asFieldAccessExpr().getScope();
@@ -504,18 +505,20 @@ public class Resolver {
                     ImportUtils.addImport(node, t);
                     types.add(t);
                 } else if (gn.getNode() instanceof ClassOrInterfaceDeclaration cid) {
-                    Optional<CallableDeclaration<?>> omd = AbstractCompiler.findCallableDeclaration(wrap, cid);
+                    Optional<Callable> omd = AbstractCompiler.findCallableDeclaration(wrap, cid);
                     if (omd.isPresent()) {
-                        CallableDeclaration<?> cd = omd.get();
-                        if (cd instanceof MethodDeclaration md) {
-                            Type t = md.getType();
-                            types.add(t);
-                            ImportUtils.addImport(node, t);
+                        Callable cd = omd.get();
+                        if (cd.isCallableDeclaration()) {
+                            if (cd.isMethodDeclaration()) {
+                                Type t = cd.asMethodDeclaration().getType();
+                                types.add(t);
+                                ImportUtils.addImport(node, t);
 
+                            }
+                            cd.getCallableDeclaration().findAncestor(ClassOrInterfaceDeclaration.class).ifPresent(c -> {
+                                ImportUtils.addImport(node, c.getNameAsString());
+                            });
                         }
-                        cd.findAncestor(ClassOrInterfaceDeclaration.class).ifPresent(c -> {
-                            ImportUtils.addImport(node, c.getNameAsString());
-                        });
                     } else {
                         Type t = lombokSolver(argMethodCall, cid, gn);
                         if (t != null) {
@@ -547,12 +550,12 @@ public class Resolver {
     static GraphNode copyMethod(MCEWrapper mceWrapper, GraphNode node) throws AntikytheraException {
         TypeDeclaration<?> cdecl = node.getEnclosingType();
         if (cdecl != null) {
-            Optional<CallableDeclaration<?>> md = AbstractCompiler.findCallableDeclaration(
+            Optional<Callable> md = AbstractCompiler.findCallableDeclaration(
                     mceWrapper, cdecl
             );
 
-            if (md.isPresent()) {
-                CallableDeclaration<?> method = md.get();
+            if (md.isPresent() && md.get().isMethodDeclaration()) {
+                MethodDeclaration method = md.get().asMethodDeclaration();
                 for (Type ex : method.getThrownExceptions()) {
                     ImportUtils.addImport(node, ex.asString());
                 }
@@ -561,9 +564,9 @@ public class Resolver {
                     Optional<ClassOrInterfaceDeclaration> parent = method.findAncestor(ClassOrInterfaceDeclaration.class);
 
                     if (!parent.get().isInterface()) {
-                        Optional<CallableDeclaration<?>> overRides = AbstractCompiler.findMethodDeclaration(mceWrapper, cdecl, false);
+                        Optional<Callable> overRides = AbstractCompiler.findMethodDeclaration(mceWrapper, cdecl, false);
                         if (overRides.isPresent()) {
-                            Graph.createGraphNode(overRides.get());
+                            Graph.createGraphNode(overRides.get().getCallableDeclaration());
                         }
                     }
                 }

--- a/src/main/java/sa/com/cloudsolutions/antikythera/evaluator/NullArgumentGenerator.java
+++ b/src/main/java/sa/com/cloudsolutions/antikythera/evaluator/NullArgumentGenerator.java
@@ -11,6 +11,7 @@ public class NullArgumentGenerator extends ArgumentGenerator{
     @Override
     public void generateArgument(Parameter param) throws ReflectiveOperationException {
         Variable variable = new Variable(null);
+        variable.setType(param.getType());
         arguments.put(param.getNameAsString(), variable);
         AntikytheraRunTime.push(variable);
     }

--- a/src/main/java/sa/com/cloudsolutions/antikythera/evaluator/Reflect.java
+++ b/src/main/java/sa/com/cloudsolutions/antikythera/evaluator/Reflect.java
@@ -90,9 +90,13 @@ public class Reflect {
         for (int i = 0; i < arguments.size(); i++) {
             argValues[i] = evaluator.evaluateExpression(arguments.get(i));
             if (argValues[i] != null) {
-                Class<?> wrapperClass = argValues[i].getClazz() == null ? argValues[i].getValue().getClass() : argValues[i].getClazz();
-                paramTypes[i] = wrapperClass;
                 args[i] = argValues[i].getValue();
+                if (argValues[i].getClazz() != null ) {
+                    paramTypes[i] = argValues[i].getClazz();
+                }
+                else if (args[i] != null) {
+                    paramTypes[i] = argValues[i].getValue().getClass();
+                }
             } else {
                 try {
                     String className = arguments.get(0).calculateResolvedType().describe();
@@ -255,5 +259,7 @@ public class Reflect {
         }
         return false;
     }
+
+
 
 }

--- a/src/main/java/sa/com/cloudsolutions/antikythera/generator/RepositoryQuery.java
+++ b/src/main/java/sa/com/cloudsolutions/antikythera/generator/RepositoryQuery.java
@@ -1,7 +1,9 @@
 package sa.com.cloudsolutions.antikythera.generator;
 
+import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.type.Type;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.BinaryExpression;
@@ -39,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import sa.com.cloudsolutions.antikythera.configuration.Settings;
 import sa.com.cloudsolutions.antikythera.evaluator.Variable;
 import sa.com.cloudsolutions.antikythera.exception.AntikytheraException;
+import sa.com.cloudsolutions.antikythera.parser.Callable;
 import sa.com.cloudsolutions.antikythera.parser.RepositoryParser;
 
 import java.sql.ResultSet;
@@ -84,7 +87,7 @@ public class RepositoryQuery {
     /**
      * The method declaration that represents the query on the JPARepository
      */
-    MethodDeclaration methodDeclaration;
+    Callable methodDeclaration;
 
     /**
      * Running the same query repeatedly will slow things down and be wastefull, lets cache it.
@@ -122,10 +125,13 @@ public class RepositoryQuery {
         return statement.toString();
     }
 
-    public void setMethodDeclaration(MethodDeclaration methodDeclaration) {
+    public void setMethodDeclaration(Callable methodDeclaration) {
         this.methodDeclaration = methodDeclaration;
-        for (int i = 0; i < methodDeclaration.getParameters().size(); i++) {
-            methodParameters.add(new QueryMethodParameter(methodDeclaration.getParameter(i), i));
+        if (methodDeclaration.isMethodDeclaration()) {
+            NodeList<Parameter> parameters = methodDeclaration.asMethodDeclaration().getParameters();
+            for (int i = 0; i < parameters.size(); i++) {
+                methodParameters.add(new QueryMethodParameter(methodDeclaration.asMethodDeclaration().getParameter(i), i));
+            }
         }
     }
 

--- a/src/main/java/sa/com/cloudsolutions/antikythera/parser/Callable.java
+++ b/src/main/java/sa/com/cloudsolutions/antikythera/parser/Callable.java
@@ -1,0 +1,95 @@
+package sa.com.cloudsolutions.antikythera.parser;
+
+import com.github.javaparser.ast.body.CallableDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+
+import java.lang.reflect.Method;
+
+/**
+ * A wrapper that unifies CallableDeclaration from java parser with reflection
+ */
+public class Callable {
+    CallableDeclaration<?> callableDeclaration;
+    Method method;
+
+    public Callable(CallableDeclaration<?> callableDeclaration) {
+        this.callableDeclaration = callableDeclaration;
+    }
+
+    public Callable(Method method) {
+        this.method = method;
+    }
+
+    public Callable() {
+
+    }
+
+    public CallableDeclaration<?> getCallableDeclaration() {
+        return callableDeclaration;
+    }
+
+    public void setCallableDeclaration(CallableDeclaration<?> callableDeclaration) {
+        this.callableDeclaration = callableDeclaration;
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public void setMethod(Method method) {
+        this.method = method;
+    }
+
+    public boolean isMethod() {
+        return method != null;
+    }
+
+    public boolean isMethodDeclaration() {
+        return callableDeclaration != null && callableDeclaration.isMethodDeclaration();
+    }
+
+    public boolean isCallableDeclaration() {
+        return callableDeclaration != null;
+    }
+
+    public MethodDeclaration asMethodDeclaration() {
+        if(isCallableDeclaration()) {
+            return callableDeclaration.asMethodDeclaration();
+        }
+        return null;
+    }
+
+    public String getNameAsString() {
+        if(isMethod()) {
+            return method.getName();
+        }
+        if (callableDeclaration != null) {
+            return callableDeclaration.getNameAsString();
+        }
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof Callable other) {
+            if (method != null) {
+                return method.equals(other.method);
+            }
+            return callableDeclaration.equals(other.callableDeclaration);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        if (method != null) {
+            return method.hashCode();
+        }
+        return callableDeclaration.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return getNameAsString();
+    }
+}

--- a/src/main/java/sa/com/cloudsolutions/antikythera/parser/ImportWrapper.java
+++ b/src/main/java/sa/com/cloudsolutions/antikythera/parser/ImportWrapper.java
@@ -12,6 +12,7 @@ public class ImportWrapper {
     private TypeDeclaration<?> type;
     private FieldDeclaration fieldDeclaration;
     private MethodDeclaration methodDeclaration;
+    private Class<?> clazz;
 
     public ImportWrapper(ImportDeclaration imp, boolean isExternal) {
         this.imp = imp;

--- a/src/main/java/sa/com/cloudsolutions/antikythera/parser/MCEWrapper.java
+++ b/src/main/java/sa/com/cloudsolutions/antikythera/parser/MCEWrapper.java
@@ -5,9 +5,13 @@ import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithArguments;
 import com.github.javaparser.ast.nodeTypes.NodeWithName;
 import com.github.javaparser.ast.type.Type;
+import sa.com.cloudsolutions.antikythera.evaluator.Reflect;
 
 /**
  * Wraps method call expressions to solve their argument types.
+ * At the time that a method call is being evaluated, typically we only have the argument names
+ * and not their types. findMethodDeclaration in AbstractCompiler requires that the types be known
+ * this class bridges that gap.
  */
 public class MCEWrapper {
     /**
@@ -24,6 +28,7 @@ public class MCEWrapper {
 
     public MCEWrapper(NodeWithArguments<?> oce) {
         this.methodCallExpr = oce;
+        argumentTypes = new NodeList<>();
     }
 
     /**
@@ -32,6 +37,20 @@ public class MCEWrapper {
      */
     public NodeList<Type> getArgumentTypes() {
         return argumentTypes;
+    }
+
+    public Class<?>[] getArgumentTypesAsClasses() throws ClassNotFoundException {
+        if (argumentTypes == null) {
+            return null;
+        }
+        Class<?>[] classes = new Class<?>[argumentTypes.size()];
+
+        for (int i = 0; i < argumentTypes.size(); i++) {
+            String elementType = argumentTypes.get(i).getElementType().toString();
+            classes[i] = Reflect.getComponentClass(elementType);
+        }
+
+        return classes;
     }
 
     /**

--- a/src/main/java/sa/com/cloudsolutions/antikythera/parser/RestControllerParser.java
+++ b/src/main/java/sa/com/cloudsolutions/antikythera/parser/RestControllerParser.java
@@ -208,9 +208,9 @@ public class RestControllerParser extends ClassProcessor {
             super.visit(md, arg);
 
             if (checkEligible(md)) {
-                evaluateMethod(md, new NullArgumentGenerator());
-                evaluateMethod(md, new DummyArgumentGenerator());
-                evaluateMethod(md, new DatabaseArgumentGenerator());
+                 evaluateMethod(md, new NullArgumentGenerator());
+                 evaluateMethod(md, new DummyArgumentGenerator());
+                 evaluateMethod(md, new DatabaseArgumentGenerator());
             }
         }
 

--- a/src/test/java/sa/com/cloudsolutions/antikythera/parser/TestRepositoryParser.java
+++ b/src/test/java/sa/com/cloudsolutions/antikythera/parser/TestRepositoryParser.java
@@ -2,16 +2,14 @@ package sa.com.cloudsolutions.antikythera.parser;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.type.PrimitiveType;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.Function;
 import net.sf.jsqlparser.expression.LongValue;
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
-import net.sf.jsqlparser.expression.operators.relational.Between;
 import net.sf.jsqlparser.expression.operators.relational.EqualsTo;
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
-import net.sf.jsqlparser.expression.operators.relational.InExpression;
 import net.sf.jsqlparser.expression.operators.relational.IsNullExpression;
 import net.sf.jsqlparser.schema.Column;
 import org.junit.jupiter.api.BeforeAll;
@@ -24,10 +22,10 @@ import sa.com.cloudsolutions.antikythera.generator.TypeWrapper;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -98,9 +96,14 @@ class TestRepositoryParser {
         AbstractCompiler.preProcess();
 
         parser.compile(AbstractCompiler.classToPath("sa.com.cloudsolutions.repository.PersonRepository"));
-        parser.process();
+        parser.processAll();
+        parser.buildQueries();
 
-        MethodDeclaration md = parser.findMethodDeclaration(new MethodCallExpr("findAll"));
-        assertNotNull(parser.get(md));
+        MCEWrapper wrapper = new MCEWrapper(new MethodCallExpr("findById"));
+        wrapper.getArgumentTypes().add(PrimitiveType.longType());
+        Optional<Callable> cd = AbstractCompiler.findCallableDeclaration(wrapper,parser.getCompilationUnit().getType(0));
+        assertTrue(cd.isPresent());
+        assertFalse(cd.get().isMethodDeclaration());
+        assertNotNull(parser.get(cd.get()));
     }
 }


### PR DESCRIPTION
A new Callable class was created as a wrapper for both `MethodDeclaration` from java parser as well as `Method` from reflection. This makes it possible to seamlessly execute code through both the evaluator and reflection.

As a consequence the methods in `AbstractCompiler` that had `MethodDeclaration` as the return type as were changed to return `Callable`.

Two old methods in `AbstractCompiler` that still accepted `MethodCallExpression` were removed.

